### PR TITLE
Add basic Jest test suite

### DIFF
--- a/__tests__/authService.test.ts
+++ b/__tests__/authService.test.ts
@@ -1,6 +1,5 @@
 const jwt = require('jsonwebtoken');
 const bcrypt = require('bcryptjs');
-jest.mock('normalize-url', () => jest.fn((u) => u));
 jest.mock('../src/models/User', () => {
   const mockModel: any = function (data: any) {
     Object.assign(this, data);

--- a/__tests__/authService.test.ts
+++ b/__tests__/authService.test.ts
@@ -1,0 +1,80 @@
+const jwt = require('jsonwebtoken');
+const bcrypt = require('bcryptjs');
+jest.mock('normalize-url', () => jest.fn((u) => u));
+jest.mock('../src/models/User', () => {
+  const mockModel: any = function (data: any) {
+    Object.assign(this, data);
+    this.save = jest.fn().mockResolvedValue(this);
+    this.toJSON = jest.fn(() => this);
+  };
+  mockModel.findOne = jest.fn();
+  mockModel.findById = jest.fn();
+  mockModel.findByIdAndUpdate = jest.fn();
+  mockModel.findByIdAndDelete = jest.fn();
+  return mockModel;
+});
+jest.mock('bcryptjs');
+jest.mock('jsonwebtoken');
+
+const authService = require('../src/services/authService');
+const User = require('../src/models/User');
+
+const mockedUser = User as jest.Mocked<typeof User>;
+
+describe('AuthService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('generateToken', () => {
+    it('should sign a JWT token', () => {
+      (jwt.sign as jest.Mock).mockReturnValue('token');
+      const token = authService.generateToken('123');
+      expect(jwt.sign).toHaveBeenCalled();
+      expect(token).toBe('token');
+    });
+  });
+
+  describe('verifyToken', () => {
+    it('should verify token', () => {
+      (jwt.verify as jest.Mock).mockReturnValue({ user: { id: '123' } });
+      const decoded = authService.verifyToken('token');
+      expect(jwt.verify).toHaveBeenCalled();
+      expect(decoded).toEqual({ user: { id: '123' } });
+    });
+
+    it('should throw on invalid token', () => {
+      (jwt.verify as jest.Mock).mockImplementation(() => { throw new Error('Invalid token'); });
+      expect(() => authService.verifyToken('bad')).toThrow('Invalid token');
+    });
+  });
+
+  describe('hashPassword & comparePassword', () => {
+    it('should hash and compare password', async () => {
+      (bcrypt.genSalt as jest.Mock).mockResolvedValue('salt');
+      (bcrypt.hash as jest.Mock).mockResolvedValue('hashed');
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      const hashed = await authService.hashPassword('pass');
+      expect(hashed).toBe('hashed');
+
+      const match = await authService.comparePassword('pass', 'hashed');
+      expect(match).toBe(true);
+    });
+  });
+
+  describe('register', () => {
+    it('should create a user and return token', async () => {
+      mockedUser.findOne.mockResolvedValue(null);
+      mockedUser.prototype.save = jest.fn().mockResolvedValue(true);
+      jest.spyOn(authService, 'generateToken').mockReturnValue('token');
+      jest.spyOn(authService, 'hashPassword').mockResolvedValue('hashed');
+      jest.spyOn(authService, 'generateAvatar').mockReturnValue('avatar');
+
+      const result = await authService.register({ name: 'n', email: 'e', password: 'p' });
+
+      expect(result).toEqual({ token: 'token', user: expect.any(Object) });
+    });
+  });
+});
+export {};

--- a/__tests__/health.test.ts
+++ b/__tests__/health.test.ts
@@ -1,0 +1,22 @@
+import request from 'supertest';
+import App from '../src/app';
+
+jest.mock('normalize-url', () => jest.fn((u) => u));
+
+jest.mock('../src/config/database', () => jest.fn());
+
+describe('Health Endpoint', () => {
+  let app: App;
+
+  beforeAll(() => {
+    app = new App();
+  });
+
+  it('responds with server status', async () => {
+    const response = await request(app.getApp()).get('/health');
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('success', true);
+    expect(response.body).toHaveProperty('message', 'Server is running');
+  });
+});
+export {};

--- a/__tests__/health.test.ts
+++ b/__tests__/health.test.ts
@@ -1,8 +1,6 @@
 import request from 'supertest';
 import App from '../src/app';
 
-jest.mock('normalize-url', () => jest.fn((u) => u));
-
 jest.mock('../src/config/database', () => jest.fn());
 
 describe('Health Endpoint', () => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  modulePathIgnorePatterns: ['<rootDir>/client', '<rootDir>/dist'],
+  coverageDirectory: 'coverage',
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   modulePathIgnorePatterns: ['<rootDir>/client', '<rootDir>/dist'],
   coverageDirectory: 'coverage',
 };

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,2 @@
+// Centralized Jest setup for common mocks
+jest.mock('normalize-url', () => jest.fn((u: string) => u));

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,10 +25,12 @@
         "normalize-url": "^8.0.0"
       },
       "devDependencies": {
+        "@types/jest": "^29.5.14",
         "@types/node": "^24.0.1",
         "jest": "^29.7.0",
         "nodemon": "^3.0.0",
         "supertest": "^6.3.0",
+        "ts-jest": "^29.4.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3"
       }
@@ -1253,6 +1255,17 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
     "node_modules/@types/node": {
       "version": "24.0.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.1.tgz",
@@ -1427,6 +1440,13 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1724,6 +1744,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/bser": {
@@ -2435,6 +2468,22 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/ejs": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.167",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.167.tgz",
@@ -2728,6 +2777,39 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/filelist": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/fill-range": {
@@ -3430,6 +3512,25 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jake": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
+      "integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^3.2.3",
+        "chalk": "^4.0.2",
+        "filelist": "^1.0.4",
+        "minimatch": "^3.1.2"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/jest": {
@@ -4501,6 +4602,13 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
@@ -6171,6 +6279,95 @@
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "bin": {
         "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-jest": {
+      "version": "29.4.0",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.0.tgz",
+      "integrity": "sha512-d423TJMnJGu80/eSgfQ5w/R+0zFJvdtTxwtF9KzFFunOpSeD+79lHJQIiAhluJoyGRbvj9NZJsl9WjCUo0ND7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "ejs": "^3.1.10",
+        "fast-json-stable-stringify": "^2.1.0",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.7.2",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ts-jest/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ts-node": {

--- a/package.json
+++ b/package.json
@@ -32,10 +32,12 @@
     "normalize-url": "^8.0.0"
   },
   "devDependencies": {
+    "@types/jest": "^29.5.14",
     "@types/node": "^24.0.1",
     "jest": "^29.7.0",
     "nodemon": "^3.0.0",
     "supertest": "^6.3.0",
+    "ts-jest": "^29.4.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
     "esModuleInterop": true,
     "skipLibCheck": true
   },
-  "include": ["src/**/*", "__tests__/**/*"]
+  "include": ["src/**/*", "__tests__/**/*", "jest.setup.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
     "esModuleInterop": true,
     "skipLibCheck": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "__tests__/**/*"]
 }


### PR DESCRIPTION
## Summary
- configure Jest with ts-jest
- include tests folder in TypeScript config
- create health endpoint test
- create AuthService unit tests
- add test dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c713bf7bc832aaf2df6ad1a10ee46