### PR TITLE
Fix auth loadUser call

### DIFF
--- a/frontend/src/store/slices/authSlice.ts
+++ b/frontend/src/store/slices/authSlice.ts
@@ -19,12 +19,13 @@ const initialState: AuthState = {
 export const loadUser = createAsyncThunk(
   "auth/loadUser",
   async (_, { rejectWithValue }) => {
-    const token =
+    const authToken =
       typeof window !== "undefined" ? localStorage.getItem("token") : null;
 
-    if (!token) {
+    if (!authToken) {
       return rejectWithValue({
         message: "No auth token provided, skipping user load.",
+        code: "NO_TOKEN",
       } as ErrorResponse);
     }
 

--- a/frontend/src/store/slices/authSlice.ts
+++ b/frontend/src/store/slices/authSlice.ts
@@ -19,6 +19,13 @@ const initialState: AuthState = {
 export const loadUser = createAsyncThunk(
   "auth/loadUser",
   async (_, { rejectWithValue }) => {
+    const token =
+      typeof window !== "undefined" ? localStorage.getItem("token") : null;
+
+    if (!token) {
+      return rejectWithValue({ message: "No token" } as ErrorResponse);
+    }
+
     try {
       const res = await axiosInstance.get("/auth/me");
       return res.data;

--- a/frontend/src/store/slices/authSlice.ts
+++ b/frontend/src/store/slices/authSlice.ts
@@ -5,6 +5,7 @@ import {
   LoginFormData,
   RegisterFormData,
   ErrorResponse,
+  ERROR_CODES,
 } from "../../types";
 
 // Initial state
@@ -25,7 +26,7 @@ export const loadUser = createAsyncThunk(
     if (!authToken) {
       return rejectWithValue({
         message: "No auth token provided, skipping user load.",
-        code: "NO_TOKEN",
+        code: ERROR_CODES.NO_TOKEN,
       } as ErrorResponse);
     }
 

--- a/frontend/src/store/slices/authSlice.ts
+++ b/frontend/src/store/slices/authSlice.ts
@@ -23,7 +23,9 @@ export const loadUser = createAsyncThunk(
       typeof window !== "undefined" ? localStorage.getItem("token") : null;
 
     if (!token) {
-      return rejectWithValue({ message: "No token" } as ErrorResponse);
+      return rejectWithValue({
+        message: "No auth token provided, skipping user load.",
+      } as ErrorResponse);
     }
 
     try {

--- a/frontend/src/types/errorCodes.ts
+++ b/frontend/src/types/errorCodes.ts
@@ -1,0 +1,5 @@
+export const ERROR_CODES = {
+  NO_TOKEN: "NO_TOKEN",
+} as const;
+
+export type ErrorCode = typeof ERROR_CODES[keyof typeof ERROR_CODES];

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -103,6 +103,8 @@ export interface ErrorResponse {
   errors?: ApiError[];
 }
 
+export * from "./errorCodes";
+
 // Redux Action Payload Types
 export interface AuthSuccessPayload {
   token: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -99,6 +99,7 @@ export interface GitHubRepo {
 // API Response Types
 export interface ErrorResponse {
   message: string;
+  code?: string;
   errors?: ApiError[];
 }
 


### PR DESCRIPTION
## Summary
- avoid calling `/auth/me` when no auth token is present

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cc2d5347c832a9f591f18235370e9